### PR TITLE
Document high-priority functions with JSDoc

### DIFF
--- a/src/rag.ts
+++ b/src/rag.ts
@@ -201,6 +201,13 @@ export interface RAGParams {
   expandPrompt?: boolean;
 }
 
+/**
+ * Performs Retrieval-Augmented Generation (RAG) to answer questions using Wikipedia content.
+ * Processes a Wikipedia article, creates embeddings, retrieves relevant context, and generates an answer.
+ * 
+ * @param params - Configuration object for the RAG process
+ * @returns Promise resolving to the generated answer string
+ */
 export default async function rag(params: RAGParams) {
   if (params.debug) {
     l.silent = false;


### PR DESCRIPTION
Add JSDoc comments for key functions that previously lacked documentation. The RAG function now has a clear description of its purpose, parameters, and return value to explain the Retrieval-Augmented Generation flow using Wikipedia content. The isEnumEntry utility also includes a concise docblock describing its inputs and boolean return, improving readability and maintainability for enum validation.